### PR TITLE
Added the possibility to disable the “Back” button and check GOLD values on chosen elements of a HIT, plus other bug fixes

### DIFF
--- a/data/download.py
+++ b/data/download.py
@@ -2498,7 +2498,7 @@ def load_data_col_names(dimensions, documents):
 df_answ = pd.DataFrame()
 
 def check_task_type(typedoc, typeslist):
-    t= typedoc['tasktype'] if 'tasktype' in typedoc.keys() else None
+    t= typedoc['task_type'] if 'task_type' in typedoc.keys() else None
     if typeslist:
             if(typeslist==True or (t in typeslist)):
                 return True
@@ -2586,7 +2586,7 @@ if not os.path.exists(df_data_path):
                     for attr in all_attrs:
                         row[f"doc_{attr}"] = np.nan
                     for dimension in dimensions:
-                        checktt= check_task_type(documents[document_data['serialization']['info']['index']], dimension['tasktype'])
+                        checktt= check_task_type(documents[document_data['serialization']['info']['index']], dimension['task_type'])
                         if dimension['scale'] is not None and checktt:
                             value = current_answers[f"{dimension['name']}_value"]
                             if type(value) == str:

--- a/data/init.py
+++ b/data/init.py
@@ -1752,15 +1752,6 @@ with console.status("Generating configuration policy", spinner="aesthetic") as s
     hits = read_json(hits_file)
     documents = hits.pop()['documents']
 
-    sample_element = {}
-
-    if len(documents) > 0:
-
-        sample_element = documents.pop()
-
-        if not 'id' in sample_element.keys():
-            raise Exception(f"Your {filename_hits_config} file does not contains an attributed called \"id\"!")
-
     # This class provides a representation of a single document stored in single hit stored in the Amazon S3 bucket.
     # The attribute <document_index> is additional and should not be touched and passed in the constructor.
     # Each field of such Document must be mapped to an attribute of this class and set up in the constructor as it is shown.
@@ -1781,6 +1772,8 @@ with console.status("Generating configuration policy", spinner="aesthetic") as s
                             contents+=[attribute]
                             try:
                                 element = value if(value == 'false' or value == 'true') else json.loads(value)
+                                if isinstance(element, bool):
+                                    print(wrapper.fill(f"{attribute}: boolean;"), file=file)
                                 if isinstance(element, dict):
                                     print(wrapper.fill(f"{attribute}: Array<JSON>;"), file=file)
                                 elif isinstance(element, int) or isinstance(element, float):
@@ -1800,6 +1793,8 @@ with console.status("Generating configuration policy", spinner="aesthetic") as s
                                         print(wrapper.fill(f"{attribute}: Array<JSON>;"), file=file)
                                     else:
                                         print(wrapper.fill(f"{attribute}: Array<String>;"), file=file)
+                                elif isinstance(value, bool):
+                                    print(wrapper.fill(f"{attribute}: boolean;"), file=file)
                                 elif isinstance(value, int) or isinstance(value, float):
                                     print(wrapper.fill(f"{attribute}: number;"), file=file)
                                 else:

--- a/src/app/components/skeleton/document/dimension/dimension.component.html
+++ b/src/app/components/skeleton/document/dimension/dimension.component.html
@@ -1,6 +1,6 @@
 <ng-template #dimensionTemplate let-dimensions="dimensions" let-position="position">
 
-    <form [formGroup]="this.assessmentForms[documentIndex]">
+    <form [formGroup]="this.assessmentForm">
 
         <div *ngFor="let dimension of dimensions; let i=index" class="dimension'">
 
@@ -85,30 +85,30 @@
                                                     (change)="this.task.storeDimensionValue($event, documentIndex,dimension.index);"
                                                     [disabled]="this.task.countdownsExpired[documentIndex] && this.task.settings.countdown_behavior=='disable_forms'">
                                             </mat-slider>
-                                            <span *ngIf="assessmentForms[documentIndex].controls[(dimension.name).concat('_value')].value==''">
+                                            <span *ngIf="assessmentForm.controls[(dimension.name).concat('_value')].value==''">
                                                 #
                                             </span>
-                                            <span *ngIf="assessmentForms[documentIndex].controls[(dimension.name).concat('_value')].value!=''">
-                                                {{assessmentForms[documentIndex].controls[(dimension.name).concat('_value')].value}}
+                                            <span *ngIf="assessmentForm.controls[(dimension.name).concat('_value')].value!=''">
+                                                {{assessmentForm.controls[(dimension.name).concat('_value')].value}}
                                             </span>
                                         </div>
                                     </ng-container>
                                     <ng-container *ngIf="dimension.scale.type=='magnitude_estimation'">
                                         <mat-form-field appearance="fill">
                                             <mat-label><span i18n>Value</span></mat-label>
-                                            <input *ngIf="dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value')}}" min="{{dimension.scale.min}}"
+                                            <input *ngIf="dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value')}}" step=".01" min="{{dimension.scale.min}}"
                                                    (change)="this.task.storeDimensionValue($event, documentIndex, dimension.index)"
                                                    [disabled]="this.task.countdownsExpired[documentIndex] && this.task.settings.countdown_behavior=='disable_forms'" class="magnitude_estimation">
-                                            <input *ngIf="!dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value')}}" min="{{dimension.scale.min}}"
+                                            <input *ngIf="!dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value')}}" step=".01" min="{{dimension.scale.min}}"
                                                    (change)="this.task.storeDimensionValue($event, documentIndex, dimension.index)" class="magnitude_estimation"
                                                    [disabled]="this.task.countdownsExpired[documentIndex] && this.task.settings.countdown_behavior=='disable_forms'">
-                                            <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value'), 'required')">
+                                            <mat-error *ngIf="this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value'), 'required')">
                                                 <span i18n>This field is required</span>
                                             </mat-error>
-                                            <mat-error *ngIf="dimension.scale.lower_bound && this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value'), 'min')">
+                                            <mat-error *ngIf="dimension.scale.lower_bound && this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value'), 'min')">
                                                 <span i18n>Value has to be grater than or equal to:</span> {{dimension.scale.min}}
                                             </mat-error>
-                                            <mat-error *ngIf="!dimension.scale.lower_bound && this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value'), 'gt')">
+                                            <mat-error *ngIf="!dimension.scale.lower_bound && this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value'), 'gt')">
                                                 <span i18n>Value has to be grater than:</span> {{dimension.scale.min}}
                                             </mat-error>
 
@@ -148,13 +148,13 @@
                                     <mat-form-field appearance="fill" class="width-100">
                                         <mat-label>{{dimension.justification.text}}</mat-label>
                                         <textarea matInput formControlName="{{dimension.name}}_justification" rows="3"></textarea>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'required')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'required')">
                                             <span i18n>This field is required</span>
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'longer')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'longer')">
                                             <span i18n>This justification must have at least</span> {{dimension.justification.min_words}} <span i18n>words</span>.
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'invalid')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'invalid')">
                                             <span i18n>You cannot use the selected search engine url as part of the justification.</span>
                                         </mat-error>
                                     </mat-form-field>
@@ -226,13 +226,13 @@
                                     <mat-form-field appearance="fill" class="width-100">
                                         <mat-label>{{dimension.justification.text}}</mat-label>
                                         <textarea matInput formControlName="{{dimension.name}}_justification" rows="5"></textarea>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'required')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'required')">
                                             <span i18n>This field is required</span>
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'longer')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'longer')">
                                             <span i18n>This justification must have at least</span> {{dimension.justification.min_words}} <span i18n>words</span>.
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification'), 'invalid')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification'), 'invalid')">
                                             <span i18n>You cannot use the selected search engine url as part of the justification.</span>
                                         </mat-error>
                                     </mat-form-field>
@@ -300,7 +300,7 @@
                                     <ng-container *ngIf="dimension.scale.type=='interval'">
                                         <div class="dimension-split-inside dimension-box" *ngFor="let pairwiseElement of this.task.documents[documentIndex]['pairwise']; let k=index">
                                             <p class="spanDocument"><span i18n>Answer for Element</span> {{k}}</p>
-                                            <label style="margin-left:10px;"><span i18n> Selected value: </span>{{assessmentForms[documentIndex].controls[(dimension.name).concat('_value_element_').concat(k)].value}}</label>
+                                            <label style="margin-left:10px;"><span i18n> Selected value: </span>{{assessmentForm.controls[(dimension.name).concat('_value_element_').concat(k)].value}}</label>
                                             <mat-slider
                                                     min="{{dimension.scale.min}}" max="{{dimension.scale.max}}"
                                                     step="{{dimension.scale.step}}" thumbLabel tickInterval="{{dimension.scale.step}}"
@@ -317,20 +317,20 @@
                                             <mat-form-field appearance="fill" style="margin-left: 10px;">
                                                 <mat-label><span i18n>Value</span></mat-label>
                                                 <input *ngIf="dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value_element_').concat(k)}}"
-                                                       min="{{dimension.scale.min}}"
+                                                       min="{{dimension.scale.min}}" step=".01"
                                                        (change)="this.task.storeDimensionValue($event, documentIndex, dimension.index) ; updateDimensionValueSelection(documentIndex,dimension.index,k)"
                                                        [disabled]="this.task.countdownsExpired[documentIndex]" class="magnitude_estimation">
                                                 <input *ngIf="!dimension.scale.lower_bound" matInput type="number" placeholder="" formControlName="{{(dimension.name).concat('_value_element_').concat(k)}}"
-                                                       min="{{dimension.scale.min}}"
+                                                       min="{{dimension.scale.min}}" step=".01"
                                                        (change)="this.task.storeDimensionValue($event, documentIndex, dimension.index); updateDimensionValueSelection(documentIndex,dimension.index,k)" class="magnitude_estimation"
                                                        [disabled]="this.task.countdownsExpired[documentIndex]">
-                                                <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value_element_').concat(k), 'required')">
+                                                <mat-error *ngIf="this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value_element_').concat(k), 'required')">
                                                     <span i18n>This field is required</span>
                                                 </mat-error>
-                                                <mat-error *ngIf="dimension.scale.lower_bound && this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value_element_').concat(k), 'min')">
+                                                <mat-error *ngIf="dimension.scale.lower_bound && this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value_element_').concat(k), 'min')">
                                                     <span i18n>Value has to be grater than or equal to:</span> {{dimension.scale.min}}
                                                 </mat-error>
-                                                <mat-error *ngIf="!dimension.scale.lower_bound && this.utilsService.hasError(assessmentForms[documentIndex], (dimension.name).concat('_value_element_').concat(k), 'gt')">
+                                                <mat-error *ngIf="!dimension.scale.lower_bound && this.utilsService.hasError(assessmentForm, (dimension.name).concat('_value_element_').concat(k), 'gt')">
                                                     <span i18n>Value has to be grater than:</span> {{dimension.scale.min}}
                                                 </mat-error>
 
@@ -362,13 +362,13 @@
                                     <mat-form-field appearance="fill">
                                         <mat-label>{{dimension.justification.text}}</mat-label>
                                         <textarea matInput formControlName="{{dimension.name}}_justification_element_{{k}}" rows="3"></textarea>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification_element_').concat(k), 'required')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification_element_').concat(k), 'required')">
                                             <span i18n>This field is required</span>
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification_element_').concat(k), 'longer')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification_element_').concat(k), 'longer')">
                                             <span i18n>This justification must have at least</span> {{dimension.justification.min_words}} <span i18n>words</span>.
                                         </mat-error>
-                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForms[documentIndex],(dimension.name).concat('_justification_element_').concat(k), 'invalid')">
+                                        <mat-error *ngIf="this.utilsService.hasError(assessmentForm,(dimension.name).concat('_justification_element_').concat(k), 'invalid')">
                                             <span i18n>You cannot use the selected search engine url as part of the justification.</span>
                                         </mat-error>
                                     </mat-form-field>
@@ -391,17 +391,17 @@
 
 <!-- Dimensions are then shown and filtered according to each position -->
 
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'top')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'top')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'top')), position:'top'}"></ng-template>
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'top')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'top')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'top')), position:'top'}"></ng-template>
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'middle')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'middle')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'middle')), position:'middle'}"></ng-template>
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'middle')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'middle')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'middle')), position:'middle'}"></ng-template>
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'bottom')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'bottom')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('list', 'bottom')), position:'bottom'}"></ng-template>
-<ng-template *ngIf="this.assessmentForms &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'bottom')).length>0" [ngTemplateOutlet]="dimensionTemplate"
+<ng-template *ngIf="this.assessmentForm &&  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'bottom')).length>0" [ngTemplateOutlet]="dimensionTemplate"
              [ngTemplateOutletContext]="{dimensions:  this.filterDimensionsCurrent(this.task.filterDimensions('matrix', 'bottom')), position:'bottom'}"></ng-template>
 
 

--- a/src/app/components/skeleton/document/dimension/dimension.component.ts
+++ b/src/app/components/skeleton/document/dimension/dimension.component.ts
@@ -34,9 +34,9 @@ export class DimensionComponent implements OnInit {
     @Input() documentIndex: number
 
     task: Task
-    assessmentForms: UntypedFormGroup[]
+    assessmentForm: UntypedFormGroup
 
-    @Output() formEmitter: EventEmitter<UntypedFormGroup>;
+    @Output() formEmitter: EventEmitter<Object>;
 
     /* References to task stepper and token forms */
     @ViewChild('stepper') stepper: MatStepper;
@@ -53,76 +53,75 @@ export class DimensionComponent implements OnInit {
         this.sectionService = sectionService
         this.utilsService = utilsService
         this.formBuilder = formBuilder
-        this.formEmitter = new EventEmitter<UntypedFormGroup>();
+        this.formEmitter = new EventEmitter<Object>();
     }
 
     ngOnInit() {
 
         this.task = this.sectionService.task
 
-        /* A form for each HIT's element is initialized */
-        this.assessmentForms = new Array<UntypedFormGroup>(this.task.documentsAmount);
-
-        for (let index = 0; index < this.task.documentsAmount; index++) {
-            let controlsConfig = {};
-            for (let index_dimension = 0; index_dimension < this.task.dimensions.length; index_dimension++) {
-                let dimension = this.task.dimensions[index_dimension];
-                if (this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].tasktype, dimension.tasktype)){
-                    if (!dimension.pairwise) {
-                        if (dimension.scale) {
+        /* A form for each the current HIT element is initialized */
+        
+        let controlsConfig = {};
+        for (let index_dimension = 0; index_dimension < this.task.dimensions.length; index_dimension++) {
+            let dimension = this.task.dimensions[index_dimension];
+            if (this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].task_type, dimension.task_type)){
+                if (!dimension.pairwise) {
+                    if (dimension.scale) {
 
 
-                            if (dimension.scale.type == "categorical") {
-                                if ((<ScaleCategorical>dimension.scale).multipleSelection) {
-                                    let answers = {}
-                                    let scale = (<ScaleCategorical>dimension.scale)
-                                    scale.mapping.forEach((value, index) => {
-                                        answers[index] = false
-                                    });
-                                    controlsConfig[`${dimension.name}_list`] = this.formBuilder.group(answers)
-                                    controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required])
-                                } else {
-                                    controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required]);
-                                }
+                        if (dimension.scale.type == "categorical") {
+                            if ((<ScaleCategorical>dimension.scale).multipleSelection) {
+                                let answers = {}
+                                let scale = (<ScaleCategorical>dimension.scale)
+                                scale.mapping.forEach((value, index) => {
+                                    answers[index] = false
+                                });
+                                controlsConfig[`${dimension.name}_list`] = this.formBuilder.group(answers)
+                                controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required])
+                            } else {
+                                controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required]);
                             }
+                        }
 
 
-                            if (dimension.scale.type == "categorical") controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required]);
-                            if (dimension.scale.type == "interval") controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.min((<ScaleInterval>dimension.scale).min), Validators.required])
+                        if (dimension.scale.type == "categorical") controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.required]);
+                        if (dimension.scale.type == "interval") controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.min((<ScaleInterval>dimension.scale).min), Validators.required])
+                        if (dimension.scale.type == "magnitude_estimation") {
+                            if ((<ScaleMagnitude>dimension.scale).lower_bound) {
+                                controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.min((<ScaleMagnitude>dimension.scale).min), Validators.required]);
+                            } else {
+                                controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [CustomValidators.gt((<ScaleMagnitude>dimension.scale).min), Validators.required]);
+                            }
+                        }
+                    }
+                    if (dimension.justification) controlsConfig[`${dimension.name}_justification`] = new UntypedFormControl('', [Validators.required, this.validateJustification.bind(this)])
+                } else {
+                    for (let j = 0; j < this.task.documents[this.documentIndex]['pairwise'].length; j++) {
+                        if (dimension.scale) {
+                            if (dimension.scale.type == "categorical") controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.required]);
+                            if (dimension.scale.type == "interval") controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.min((<ScaleInterval>dimension.scale).min), Validators.required])
                             if (dimension.scale.type == "magnitude_estimation") {
                                 if ((<ScaleMagnitude>dimension.scale).lower_bound) {
-                                    controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [Validators.min((<ScaleMagnitude>dimension.scale).min), Validators.required]);
+                                    controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.min((<ScaleMagnitude>dimension.scale).min), Validators.required]);
                                 } else {
-                                    controlsConfig[`${dimension.name}_value`] = new UntypedFormControl('', [CustomValidators.gt((<ScaleMagnitude>dimension.scale).min), Validators.required]);
+                                    controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [CustomValidators.gt((<ScaleMagnitude>dimension.scale).min), Validators.required]);
                                 }
                             }
                         }
-                        if (dimension.justification) controlsConfig[`${dimension.name}_justification`] = new UntypedFormControl('', [Validators.required, this.validateJustification.bind(this)])
-                    } else {
-                        for (let j = 0; j < this.task.documents[index]['pairwise'].length; j++) {
-                            if (dimension.scale) {
-                                if (dimension.scale.type == "categorical") controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.required]);
-                                if (dimension.scale.type == "interval") controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.min((<ScaleInterval>dimension.scale).min), Validators.required])
-                                if (dimension.scale.type == "magnitude_estimation") {
-                                    if ((<ScaleMagnitude>dimension.scale).lower_bound) {
-                                        controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [Validators.min((<ScaleMagnitude>dimension.scale).min), Validators.required]);
-                                    } else {
-                                        controlsConfig[`${dimension.name}_value_element_${j}`] = new UntypedFormControl('', [CustomValidators.gt((<ScaleMagnitude>dimension.scale).min), Validators.required]);
-                                    }
-                                }
-                            }
-                            if (dimension.justification) controlsConfig[`${dimension.name}_justification_element_${j}`] = new UntypedFormControl('', [Validators.required, this.validateJustification.bind(this)])
-                        }
+                        if (dimension.justification) controlsConfig[`${dimension.name}_justification_element_${j}`] = new UntypedFormControl('', [Validators.required, this.validateJustification.bind(this)])
                     }
                 }
             }
-            let assessmentForm = this.formBuilder.group(controlsConfig)
-            assessmentForm.valueChanges.subscribe(values => {
-                this.formEmitter.emit(assessmentForm)
-            })
-            this.assessmentForms[index] = assessmentForm
-            this.formEmitter.emit(assessmentForm)
         }
+
+
+        let assessForm = this.formBuilder.group(controlsConfig)
+        this.assessmentForm = assessForm
+        this.formEmitter.emit({
+            "index": this.documentIndex,
+            "form": assessForm
+        })
     }
 
     /*
@@ -142,7 +141,7 @@ export class DimensionComponent implements OnInit {
                 cleanedWords.push(trimmedWord)
             }
         }
-        if (this.assessmentForms[this.documentIndex]) {
+        if (this.assessmentForm) {
             /* The current document document_index is selected */
             let currentDocument = this.documentIndex;
             /* If the user has selected some search engine responses for the current document */
@@ -156,7 +155,7 @@ export class DimensionComponent implements OnInit {
                     }
                 }
             }
-            const allControls = this.assessmentForms[this.documentIndex].controls;
+            const allControls = this.assessmentForm.controls;
             let currentControl = Object.keys(allControls).find(name => control === allControls[name])
             if (currentControl) {
                 let currentDimensionName = currentControl.split("_")[0]
@@ -168,8 +167,8 @@ export class DimensionComponent implements OnInit {
 
     public storeSearchEngineUrl(urlFormGroup, dimensionIndex) {
         for (const [key, value] of Object.entries(urlFormGroup.controls)) {
-            if (!this.assessmentForms[dimensionIndex].get(key) && this.task.dimensions[dimensionIndex].url) {
-                this.assessmentForms[dimensionIndex].addControl(key, urlFormGroup.get(key))
+            if (!this.assessmentForm.get(key) && this.task.dimensions[dimensionIndex].url) {
+                this.assessmentForm.addControl(key, urlFormGroup.get(key))
             }
         }
     }
@@ -197,7 +196,7 @@ export class DimensionComponent implements OnInit {
         let result = true
         for (let dimension of dimensionsToCheck) {
             if (dimension.url) {
-                let dimensionForm = this.assessmentForms[dimension.index]
+                let dimensionForm = this.assessmentForm
                 if (dimensionForm.get(dimension.name.concat("_url"))) {
                     let value = dimensionForm.get(dimension.name.concat("_url")).value
                     if (!value)
@@ -210,8 +209,8 @@ export class DimensionComponent implements OnInit {
 
     public handleCheckbox(data, dimension, index) {
         let controlValid = false
-        let formGroup = this.assessmentForms[this.documentIndex].get(dimension.name.concat('_list'))
-        let formControl = this.assessmentForms[this.documentIndex].get(dimension.name.concat('_value'))
+        let formGroup = this.assessmentForm.get(dimension.name.concat('_list'))
+        let formControl = this.assessmentForm.get(dimension.name.concat('_value'))
         formGroup.get(index.toString()).setValue(data['checked'])
         for (const [key, value] of Object.entries(formGroup.value)) {
             if (value)
@@ -245,7 +244,7 @@ export class DimensionComponent implements OnInit {
     public filterDimensionsCurrent(dimensions) {
         let filteredDimensions = [];
         for (let dimension of dimensions) {
-            if (this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].tasktype, dimension.tasktype)) 
+            if (this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].task_type, dimension.task_type)) 
                 filteredDimensions.push(dimension);
         }
         return filteredDimensions;

--- a/src/app/components/skeleton/document/document.component.html
+++ b/src/app/components/skeleton/document/document.component.html
@@ -2,11 +2,11 @@
     <mat-card>
 
         <mat-card-title>
-            <ng-container *ngIf="this.document.tasktype==undefined">
+            <ng-container *ngIf="this.document.task_type==undefined">
                 <span i18n>Element</span> {{this.getDocTypeNumber()}}
             </ng-container>
-            <ng-container *ngIf="!(this.document.tasktype==undefined)">
-                {{this.document.tasktype}} <span i18n>Element</span> {{this.getDocTypeNumber()}}
+            <ng-container *ngIf="!(this.document.task_type==undefined)">
+                {{this.document.task_type}} <span i18n>Element</span> {{this.getDocTypeNumber()}}
             </ng-container>
         </mat-card-title>
 
@@ -20,8 +20,8 @@
             </ng-container>
             <div *ngIf="this.task.instructionsEvaluation.instructions.length>0" class="evaluation-instructions">
                 <div *ngFor="let instruction of this.task.instructionsEvaluation.instructions">
-                    <h2 *ngIf="this.utilsService.isCurrentTaskType(this.document.tasktype, instruction.tasktype)">{{instruction.caption}}</h2>
-                    <div *ngIf="this.utilsService.isCurrentTaskType(this.document.tasktype, instruction.tasktype)"><p [innerHTML]="instruction.text"></p></div>
+                    <h2 *ngIf="this.utilsService.isCurrentTaskType(this.document.task_type, instruction.task_type)">{{instruction.caption}}</h2>
+                    <div *ngIf="this.utilsService.isCurrentTaskType(this.document.task_type, instruction.task_type)"><p [innerHTML]="instruction.text"></p></div>
                 </div>
             </div>
 
@@ -51,17 +51,17 @@
 
             <!-- "Back", "Next" and "Finish" actions markup -->
             <mat-card-actions *ngIf="this.assessmentForm">
-                <button mat-flat-button color="primary" matStepperPrevious *ngIf="documentIndex>0"
+                <button mat-flat-button color="primary"  *ngIf="documentIndex>0 && !(this.document.allow_back==false)"
                         [disabled]="this.sectionService.taskCompleted"
                         (click)="handleDocumentCompletion('Back')">
                     <span i18n>Back</span>
                 </button>
-                <button mat-flat-button color="primary" matStepperNext *ngIf="documentIndex+1<this.task.documentsAmount || (documentIndex+1>=this.task.documentsAmount && this.task.questionnaireAmountEnd > 0)"
+                <button mat-flat-button color="primary"  *ngIf="documentIndex+1<this.task.documentsAmount || (documentIndex+1>=this.task.documentsAmount && this.task.questionnaireAmountEnd > 0)"
                         [disabled]="((!assessmentForm.valid || assessmentForm.status == 'DISABLED' ) || !this.task.searchEngineRetrievedResponses[documentIndex] || this.sectionService.taskCompleted || !this.task.checkAnnotationConsistency(documentIndex))"
                         (click)="handleDocumentCompletion('Next')">
                     <span i18n>Next</span>
                 </button>
-                <button mat-stroked-button color="accent" matStepperNext
+                <button mat-stroked-button color="accent" 
                         *ngIf="documentIndex+1>=this.task.documentsAmount && this.task.questionnaireAmountEnd == 0"
                         [disabled]="(!assessmentForm.valid || assessmentForm.status == 'DISABLED'  || !this.task.searchEngineRetrievedResponses[documentIndex] || this.sectionService.taskCompleted || !this.task.checkAnnotationConsistency(documentIndex))"
                         (click)="handleDocumentCompletion('Finish')">

--- a/src/app/components/skeleton/document/document.component.ts
+++ b/src/app/components/skeleton/document/document.component.ts
@@ -1,5 +1,5 @@
 /* Core */
-import {ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChildren} from '@angular/core';
+import {ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChildren, ViewChild} from '@angular/core';
 import {AbstractControl, UntypedFormBuilder, UntypedFormGroup} from "@angular/forms";
 /* Services */
 import {SectionService} from "../../../services/section.service";
@@ -8,10 +8,14 @@ import {DeviceDetectorService} from "ngx-device-detector";
 /* Models */
 import {Task} from "../../../models/skeleton/task";
 import {Document} from "../../../../../data/build/skeleton/document";
+import { GoldChecker } from "../../../../../data/build/skeleton/goldChecker";
 /* Components */
 import {AnnotatorOptionsComponent} from "./elements/annotator-options/annotator-options.component";
 import {DimensionComponent} from "./dimension/dimension.component";
 import {CountdownComponent} from "ngx-countdown";
+/* Material Design */
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { MatStepper } from "@angular/material/stepper";
 
 @Component({
     selector: 'app-document',
@@ -29,7 +33,12 @@ export class DocumentComponent implements OnInit {
     /* Angular Reactive Form builder (see https://angular.io/guide/reactive-forms) */
     formBuilder: UntypedFormBuilder;
 
+    /* Snackbar reference */
+    snackBar: MatSnackBar;
+
     @Input() documentIndex: number
+    @Input() documentsForm: UntypedFormGroup[]
+    @Input() stepper: MatStepper
 
     /* Reference to the outcome section component */
     @ViewChildren(AnnotatorOptionsComponent) annotatorOptions: QueryList<AnnotatorOptionsComponent>;
@@ -52,6 +61,7 @@ export class DocumentComponent implements OnInit {
         deviceDetectorService: DeviceDetectorService,
         sectionService: SectionService,
         utilsService: UtilsService,
+        snackBar: MatSnackBar,
         formBuilder: UntypedFormBuilder
     ) {
         this.changeDetector = changeDetector
@@ -60,6 +70,7 @@ export class DocumentComponent implements OnInit {
         this.formBuilder = formBuilder
         this.formEmitter = new EventEmitter<Object>();
         this.task = this.sectionService.task
+        this.snackBar = snackBar;
     }
 
     ngOnInit(): void {
@@ -72,21 +83,12 @@ export class DocumentComponent implements OnInit {
 
     /* |--------- DIMENSIONS ---------| */
 
-    public storeAssessmentForm(form) {
-        if (!this.assessmentForm) {
+
+    public storeAssessmentForm(data) {
+        let documentIndex = data['index'] as number
+        let form = data['form']
+        if (!this.assessmentForm && this.documentIndex == documentIndex) {
             this.assessmentForm = form
-        } else {
-            for (const [name, control] of Object.entries(form.controls)) {
-                if (control instanceof AbstractControl) {
-                    if (control.valid) {
-                        if(this.assessmentForm.get(name))
-                            this.assessmentForm.get(name).setValue(form.get(name).value, {emitEvent: false})
-                        else {
-                            this.assessmentForm.addControl(name, form.get(name), {emitEvent: false})
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -105,6 +107,26 @@ export class DocumentComponent implements OnInit {
     }
 
     public handleDocumentCompletion(action: string) {
+
+        if((action=="Next" || action=="Finish") && typeof this.document["check_gold_with_msg"] === 'string'){
+            let docsForms = this.documentsForm.slice()
+            docsForms.push(this.assessmentForm)
+
+            let goldConfiguration = this.utilsService.generateGoldConfiguration(this.task.goldDocuments,this.task.goldDimensions, docsForms, this.task.notes);
+            let goldChecks = GoldChecker.performGoldCheck(goldConfiguration);
+
+            if(goldChecks.every(Boolean))
+                this.stepper.next();
+            else
+                this.snackBar.open(this.document["check_gold_with_msg"], "Dismiss", {duration: 10000});
+        }
+        else{
+            if(action=="Back")
+                this.stepper.previous();
+            else
+                this.stepper.next();
+        }
+
         this.formEmitter.emit({
             "form": this.assessmentForm,
             "action": action
@@ -126,7 +148,7 @@ export class DocumentComponent implements OnInit {
     public getDocTypeNumber() {
         let count=0
         for (let index = 0; index <= this.documentIndex; index++) {
-            if (this.document.tasktype == this.task.documents[index].tasktype) 
+            if (this.document.task_type == this.task.documents[index].task_type) 
                 count++;
         }
         return count;

--- a/src/app/components/skeleton/document/elements/element-pointwise/element-pointwise.component.html
+++ b/src/app/components/skeleton/document/elements/element-pointwise/element-pointwise.component.html
@@ -1,6 +1,6 @@
 <div class="statement" *ngIf="(this.task.settings.modality=='pointwise')">
     <ng-container *ngFor="let attribute of this.task.settings.attributes; let k=index">
-      <div *ngIf="this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].tasktype, attribute.show)" class="attribute">
+      <div *ngIf="this.utilsService.isCurrentTaskType(this.task.documents[this.documentIndex].task_type, attribute.show)" class="attribute">
         <p class="attribute-label">
           <strong *ngIf="attribute.name_pretty">{{attribute.name_pretty}}: </strong>
           <strong *ngIf="!attribute.name_pretty">{{attribute.name.split('_').join(' ') | titlecase}}: </strong>

--- a/src/app/components/skeleton/skeleton.component.html
+++ b/src/app/components/skeleton/skeleton.component.html
@@ -95,6 +95,8 @@
             <app-document
                     *ngIf="this.task.getElementIndex(stepIndex)['elementType'] == 'S'"
                     [documentIndex]="this.task.getElementIndex(stepIndex)['elementIndex']"
+                    [documentsForm]="this.documentsForm"
+                    [stepper]="this.stepper"
                     (formEmitter)="this.storeDocumentForm($event, this.task.getElementIndex(stepIndex)['elementIndex'])"
             ></app-document>
         </mat-step>

--- a/src/app/components/skeleton/skeleton.component.ts
+++ b/src/app/components/skeleton/skeleton.component.ts
@@ -1243,28 +1243,7 @@ export class SkeletonComponent implements OnInit {
 
         /* 2) GOLD ELEMENTS CHECK performed here */
 
-        let goldConfiguration = [];
-        /* For each gold document its attribute, answers and notes are retrieved to build a gold configuration */
-        for (let goldDocument of this.task.goldDocuments) {
-            let currentConfiguration = {};
-            currentConfiguration["document"] = goldDocument;
-            let answers = {};
-            for (let goldDimension of this.task.goldDimensions) {
-                for (let [attribute, value] of Object.entries(
-                    this.documentsForm[goldDocument.index].value
-                )) {
-                    let dimensionName = attribute.split("_")[0];
-                    if (dimensionName == goldDimension.name) {
-                        answers[attribute] = value;
-                    }
-                }
-            }
-            currentConfiguration["answers"] = answers;
-            currentConfiguration["notes"] = this.task.notes
-                ? this.task.notes[goldDocument.index]
-                : [];
-            goldConfiguration.push(currentConfiguration);
-        }
+        let goldConfiguration = this.utilsService.generateGoldConfiguration(this.task.goldDocuments,this.task.goldDimensions, this.documentsForm, this.task.notes);
 
         /* The gold configuration is evaluated using the static method implemented within the GoldChecker class */
         let goldChecks = GoldChecker.performGoldCheck(goldConfiguration);

--- a/src/app/models/skeleton/dimension.ts
+++ b/src/app/models/skeleton/dimension.ts
@@ -19,7 +19,7 @@ export class Dimension {
     scale?: ScaleCategorical | ScaleInterval | ScaleMagnitude | ScalePairwise;
     gold?: boolean;
     style: Style;
-    tasktype: Array<string>;
+    task_type: Array<string>;
 
     constructor(
         index: number,
@@ -32,7 +32,7 @@ export class Dimension {
             delete data['gold_question_check']
         }
         this.name = data["name"];
-        this.tasktype = data["tasktype"] ? data["tasktype"] : null ;
+        this.task_type = data["task_type"] ? data["task_type"] : null ;
         this.name_pretty = data['name_pretty'] ? data["name_pretty"] : null;
         this.description = data['description'] ? data["description"] : null;
         this.example = data['example'] ? data["example"] : null;

--- a/src/app/models/skeleton/instructions.ts
+++ b/src/app/models/skeleton/instructions.ts
@@ -9,7 +9,7 @@ export class Instruction {
     caption?: string;
     label?: string;
     text: string;
-    tasktype: Array<string>;
+    task_type: Array<string>;
 
     constructor(
         index: number,
@@ -26,7 +26,7 @@ export class Instruction {
         } else {
             this.text = data['text'] ? data["text"] : null;
         }
-        this.tasktype = data['tasktype'] ? data["tasktype"] : null;
+        this.task_type = data['task_type'] ? data["task_type"] : null;
     }
 
 }

--- a/src/app/models/skeleton/task.ts
+++ b/src/app/models/skeleton/task.ts
@@ -407,16 +407,17 @@ export class Task {
      * These information are parsed and stored in the corresponding data structure.
      */
     public storeDimensionValue(
-        valueData: Object,
+        eventData: Event,
         document: number,
         dimension: number
     ) {
+        let eventTarget = eventData.target as HTMLInputElement
         /* The current document, dimension and user query are copied from parameters */
         let currentDocument = document;
         let currentDimension = dimension;
         /* A reference to the current dimension is saved */
         this.currentDimension = currentDimension;
-        let currentValue = valueData["value"];
+        let currentValue = eventTarget.value;
         let timeInSeconds = Date.now() / 1000;
         /* If some data for the current document already exists*/
         if (this.dimensionsSelectedValues[currentDocument]["amount"] > 0) {

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -136,4 +136,34 @@ export class UtilsService {
     }
 
 
+    public generateGoldConfiguration(goldDocuments, goldDimensions, documentsForm, notes) {
+        let goldConfiguration = [];
+
+        /* For each gold document its attribute, answers and notes are retrieved to build a gold configuration */
+        for (let goldDocument of goldDocuments) {
+            if(goldDocument.index<documentsForm.length){
+                let currentConfiguration = {};
+                currentConfiguration["document"] = goldDocument;
+                let answers = {};
+                for (let goldDimension of goldDimensions) {
+                    for (let [attribute, value] of Object.entries(
+                        documentsForm[goldDocument.index].value
+                    )) {
+                        let dimensionName = attribute.split("_")[0];
+                        if (dimensionName == goldDimension.name) {
+                            answers[attribute] = value;
+                        }
+                    }
+                }
+                currentConfiguration["answers"] = answers;
+                currentConfiguration["notes"] = notes
+                    ? notes[goldDocument.index]
+                    : [];
+                goldConfiguration.push(currentConfiguration);
+            }
+        }
+
+        return goldConfiguration;
+    }
+
 }


### PR DESCRIPTION
-	changed “tasktype” to “task_type”
-	if new setting “allow_back” is set to false for a element of the HIT (in hits.json), then for that element the “Back” button will not be shown
-	if new setting “check_gold_with_msg” is set with a string for a element of the HIT (in hits.json), then for that element when the “Next” button is pressed, the check in goldChecker.ts will be performed and if positive the next element of the HIT will be presented, otherwise a snackbar with the given string value of “check_gold_with_msg” will be shown
-	2 bugs fixed: 
        1. Decimal numbers can now be typed correctly for Magnitude Estimation scale 
        2. “Next” button is not shown “active” anymore after the first element of a HIT, when the Magnitude Estimation textbox value is emptied